### PR TITLE
Added enhancements to SyscallParameter parsing module

### DIFF
--- a/sysDef/SyscallManual.py
+++ b/sysDef/SyscallManual.py
@@ -48,6 +48,19 @@ from Definition import Definition
 # controls printing
 DEBUG = False
 
+class SyscallManualException(Exception):
+    """
+    <Purpose>
+      A SyscallManualException is a custom exception that is passed specifically
+      when parsing the man page definition is erroneous. This may be the case
+      for system calls that are unimplemented and therefore erroneous, but we
+      do not want to interrupt program execution and continue parsing.
+
+    <Attributes>
+      None
+    """
+    pass
+
 
 class SyscallManual:
     """
@@ -227,7 +240,7 @@ class SyscallManual:
         # page given above for more information.
         while True:
             if len(man_page_lines) == 0:
-                raise Exception("Reached end of man page while looking for SYNOPSIS ine")
+                raise SyscallManualException("Reached end of man page while looking for SYNOPSIS line for {}.".format(syscall_name))
 
             # read the first line
             line = man_page_lines[0]
@@ -250,7 +263,7 @@ class SyscallManual:
         all_definitions = []
         while True:
             if len(man_page_lines) == 0:
-                raise Exception("Reached end of man page while looking for DESCRIPTION line.")
+                raise SyscallManualException("Reached end of man page while looking for DESCRIPTION line for {}.".format(syscall_name))
 
             line = man_page_lines.pop(0).strip()
 

--- a/sysDef/SyscallManual.py
+++ b/sysDef/SyscallManual.py
@@ -52,43 +52,43 @@ DEBUG = False
 class SyscallManual:
     """
     <Purpose>
-      A SyscallManual is made up of the system call name and its definition 
+      A SyscallManual is made up of the system call name and its definition
       parsed from its man page.
-    
+
       The reason of having this object in addition to the Definition object is
       because the name of the system call and the definition name are not
       necessarily the same, but most of the times are. For example the name of the
       system call can be 'chown32' and the name of its definition 'chown'.
-    
+
       Some intuition regarding the above taken from chown man page:
-      The original Linux chown(), fchown(), and lchown()  system  calls  supported only 16-bit user 
+      The original Linux chown(), fchown(), and lchown()  system  calls  supported only 16-bit user
       and group IDs. Subsequently, Linux 2.4 added chown32(), fchown32(), and lchown32(), supporting
       32-bit IDs. The glibc  chown(),  fchown(), and lchown() wrapper functions transparently
       deal with the variations across kernel versions.
-    
+
     <Attributes>
       name:
         The name of the system call
-      
+
       type:
         The type of the definition. Can be one of:
          - NO_MAN_ENTRY:
             no man entry was found for this syscall name
-    
+
          - NOT_FOUND:
             man entry found but no definition found inside
-    
+
          - UNIMPLEMENTED:
             syscall identified as unimplemented
-    
+
          - FOUND:
             definition for this system call was found
-    
-      
+
+
       definition:
-        Holds the definition object if the type is FOUND. Otherwise definition is 
+        Holds the definition object if the type is FOUND. Otherwise definition is
         set to None.
-    
+
     """
 
     # types of SyscallManual.
@@ -102,22 +102,22 @@ class SyscallManual:
         """
         <Purpose>
           Creates a SyscallManual object.
-        
+
           A SyscallManual object has a name, which is the name of the system
           call, a type, which is defined in terms of the four types given above and
           finally, a definition object.
-        
+
         <Arguments>
           syscall_name:
-            The name of the system call for which to create a SyscallManual 
+            The name of the system call for which to create a SyscallManual
             object.
-        
+
         <Exceptions>
           None
-        
+
         <Side Effects>
           None
-        
+
         <Returns>
           None
         """
@@ -131,17 +131,17 @@ class SyscallManual:
           Reads the man entry of the system call whose name is given as a parameter
           and returns its definition as a Description object along with what kind of
           definition it is.
-        
+
         <Arguments>
           syscall_name:
             The name of the system call for which to get the definition.
-        
+
         <Exceptions>
           None
-        
+
         <Side Effects>
           None
-        
+
         <Returns>
           (self.NO_MAN_ENTRY, None):   if no manual entry was found.
           (self.NOT_FOUND, None):      if man entry found but definition not found.
@@ -168,31 +168,31 @@ class SyscallManual:
 
         """
         Example of the open man page, upto the definitions part:
-        
+
         <--start example-->
               OPEN(2)                  Linux Programmer's Manual           OPEN(2)
-        
+
               NAME
                      open, creat - open and possibly create a file or device
-        
+
               SYNOPSIS
                      #include <sys/types.h>
                      #include <sys/stat.h>
                      #include <fcntl.h>
-        
+
                      int open(const char *pathname, int flags);
                      int open(const char *pathname, int flags, mode_t mode);
-        
+
                      int creat(const char *pathname, mode_t mode);
-        
+
               DESCRIPTION
         <--end example-->
-        
-        
+
+
         Note that, as shown in the example above, a man page can have multiple
         definitions for the same system call (2 definitions given for open) and it
         can also include definitions of similar but different system calls (creat).
-        
+
         """
 
         # in some platforms attempts to access the man page of system calls ending

--- a/sysDef/SyscallParameter.py
+++ b/sysDef/SyscallParameter.py
@@ -42,6 +42,11 @@ class SyscallParameter:
       self.const_pointer:
         int execve(const char *filename, char *const argv[], char *const envp[])
 
+      self.short:
+        unsigned char inb(unsigned short int port)
+
+      self.long:
+        void insl(unsigned short int port, void *addr, unsigned long int count)
     """
 
     def __init__(self, parameter_string):

--- a/sysDef/SyscallParameter.py
+++ b/sysDef/SyscallParameter.py
@@ -1,4 +1,3 @@
-
 class SyscallParameter:
     """
     <Purpose>
@@ -93,6 +92,8 @@ class SyscallParameter:
         self.unsigned = False
         self.function = False
         self.const_pointer = False
+        self.short = False
+        self.long = False
 
         # a parameter could be the ellipsis ("...")
         if(parameter_string == "..."):
@@ -145,6 +146,10 @@ class SyscallParameter:
                 self.union = True
             elif(item == "enum"):
                 self.enum = True
+            elif(item == "short"):
+                self.short = True
+            elif(item == "long"):
+                self.long = True
             else:
                 # it could be a constant pointer eg char *const argv[] in execve in
                 # which case the item variable holds the correct type of the pointer and
@@ -181,6 +186,13 @@ class SyscallParameter:
 
         if(self.unsigned):
             representation += "unsigned "
+
+        # short / long modifier comes immediately before type
+        if(self.short):
+            representation += "short "
+
+        if(self.long):
+            representation += "long "
 
         representation += str(self.type) + " "
 
@@ -226,6 +238,13 @@ class SyscallParameter:
 
         if(self.unsigned):
             representation += "unsigned, "
+
+        # short / long modifier comes immediately before type
+        if(self.short):
+            representation += "short, "
+
+        if(self.long):
+            representation += "long, "
 
         representation += str(self.type) + ", "
 


### PR DESCRIPTION
When parsing a system call like `inb` on my system, function parameters that are found within the synopsis include:

```
$ man 2 inb
unsigned char inb(unsigned short int port);
```

When `SyscallParameter.py` takes in calls like these, it is unable to identify `short` and `long` as data types, and as a result, fails. This PR adds this feature to `SyscallParameter.py` within the `sysDef` module, such that it is able to parse arguments that include `short` / `long` as part of its type.

I will be following up with a separate PR regarding the `parse_syscall_definitions.py` optimizations that I have mentioned in the past. 