### PR TITLE
Fix for rr_ system call problem, and other specified fixes

### DIFF
--- a/posix_omni_parser/Syscall.py
+++ b/posix_omni_parser/Syscall.py
@@ -6,7 +6,7 @@
   Savvas Savvides <savvas@purdue.edu>
 
 <Purpose>
-  
+
 
 """
 
@@ -20,12 +20,12 @@ class UnfinishedSyscall:
     If a syscall is interrupted or blocked, it will be split in multiple lines.
     This object is used to store the partial system call information included in
     the unfinished syscall.
-    
+
     Example from strace output:
     19176 accept(3, <unfinished ...>
-    19175 connect(5, {sa_family=AF_INET, sin_port=htons(25588), 
+    19175 connect(5, {sa_family=AF_INET, sin_port=htons(25588),
                       sin_addr=inet_addr("127.0.0.1")}, 16) = 0
-    19176 <... accept resumed> {sa_family=AF_INET, sin_port=htons(42572), 
+    19176 <... accept resumed> {sa_family=AF_INET, sin_port=htons(42572),
                                 sin_addr=inet_addr("127.0.0.1")}, [16]) = 4
     """
 
@@ -36,7 +36,7 @@ class UnfinishedSyscall:
 
     def __eq__(self, other):
         """
-        Equality of Unfinished system calls is based on the pid and the name of the 
+        Equality of Unfinished system calls is based on the pid and the name of the
         system call.
         """
         return self.pid == other.pid and self.name == other.name
@@ -53,43 +53,43 @@ class Syscall:
     """
     <Purpose>
       This object is used to describe a system call, holding all the information
-      extracted from the trace file. The same object is used to describe system 
+      extracted from the trace file. The same object is used to describe system
       calls independently on which utility was used to generate the trace file.
-    
+
     <Attributes>
       self.original_line:
         A string holding the original line from which this object was created.
-    
+
       self.type:
         The type of the system call. This can be one of the UNFINISHED, RESUMED or
         COMPLETE.
-    
+
       self.pid:
         The process id of this system call.
-    
+
       self.name:
         The name of the system call.
-    
+
       self.args:
         A tuple containing all the arguments of the system call. The value of each
         argument can be either a string or wrapped into a more meaningful class.
-    
+
       self.ret:
         A tuple holding the return part of the system call. This tuple should
         always contain two items. The first one is the return value of the system
         call. The second is either a string holding the error label eg "EACCES"
-        in case the system call had an error or None if the syscall executed 
+        in case the system call had an error or None if the syscall executed
         correctly.
-      
+
       self.inst_pointer:
         The instruction pointer at the time of the system call.
-    
+
       self.timestamp:
         This value can have different formats and content according to the parser
         options. For example it can hold  a relative timestamp indicating the
         interval between the beginning of successive syscalls or it can hold the
         time the syscall was executed.
-    
+
       self.elapsed_time:
         The time difference between the beginning and the end of the system call.
     """
@@ -114,27 +114,27 @@ class Syscall:
         <Purpose>
           Initialize a Syscall object. Create the data fields of the object. If the
           information needed for a data field is not given, set the value of that
-          data field to None. Cast the system call arguments into meaningful 
+          data field to None. Cast the system call arguments into meaningful
           classes.
-        
+
         <Arguments>
           syscall_definitions:
             A list of system call definitions used to parse the arguments of the
             system call into more meaningful classes.
-          
+
           line:
             The original line from which the Syscall object is derived.
-          
+
           line_parts:
             A list containing the parts of the trace line. E.g: type, pid, name,
             args, return, timestamp, etc ...
-        
+
         <Exceptions>
           None
-        
+
         <Side Effects>
           None
-        
+
         <Returns>
           None
         """
@@ -151,9 +151,17 @@ class Syscall:
 
         # at this point all system call arguments are represented as strings. Let's
         # cast them into more meaningful classes.
-        self.args = parsing_classes.cast_args(self.name, line_parts["type"],
-                                              syscall_definitions,
-                                              line_parts["args"])
+
+        # when casting arguments, a comparsion against our pickle file is made. If
+        # rr has injected its own syscalls within the trace, we skip this part
+        # and set the self.args parameter to an arbitrary None, as we don't care
+        # about it.
+        if "syscall_" not in self.name:
+            self.args = parsing_classes.cast_args(self.name, line_parts["type"],
+                                                  syscall_definitions,
+                                                  line_parts["args"])
+        else:
+            self.args = None
 
         self.ret = line_parts["return"]
 
@@ -173,7 +181,7 @@ class Syscall:
 
     def isSuccessful(self):
         """
-        If the first item of the return part is -1 or ? it means the syscall 
+        If the first item of the return part is -1 or ? it means the syscall
         returned an error or did not return. Otherwise it was successful.
         """
         return self.ret[0] != -1 and self.ret[0] != "?"


### PR DESCRIPTION
The original exception:

```
Traceback (most recent call last):
  File "./inject.py", line 423, in <module>
    main(sys.argv[1])
  File "./inject.py", line 358, in main
    trace = Trace.Trace(config_dict['trace_file'])
  File "/home/testbed/isolate/rrapper/crashsim/local/lib/python2.7/site-packages/posix_omni_parser/Trace.py", line 105, in __init__
    self.syscalls = self.parser.parse_trace()
  File "/home/testbed/isolate/rrapper/crashsim/local/lib/python2.7/site-packages/posix_omni_parser/parsers/StraceParser.py", line 587, in parse_trace
    line_parts))
  File "/home/testbed/isolate/rrapper/crashsim/local/lib/python2.7/site-packages/posix_omni_parser/Syscall.py", line 156, in __init__
    line_parts["args"])
  File "/home/testbed/isolate/rrapper/crashsim/local/lib/python2.7/site-packages/posix_omni_parser/parsing_classes.py", line 655, in cast_args
    if syscall_definition.definition != None:
AttributeError: 'NoneType' object has no attribute 'definition'
Injector for event:rec_pid 280:1940 failed
```
This was attributed to the fact that when `cast_args` is called within the `Syscall` class, it compares the specified syscall against the definitions in the `syscall_definitions.pickle` file, and if not found, the syscall retained a `NoneType`, resulting in a `AttributeError`. In order to fix this, I introduced logic that simply ignored the `cast_args` call, and set `self.args` to an arbitrary `None`, as we do not actually care about this system call. This way, the system call is still present within the trace, but won't blow up runtime execution.

Two other problems were identified along the way while fixing the `rr_` custom syscall problem as well.

This is attributed to the fact that when `bind(2)` calls with `AF_NETLINK` are passed, it is expected that they have this sort of strace signature:

```
11597 bind(3, {sa_family=AF_NETLINK, pid=0, groups=00000000}, 12) = 0
```

However, the result of my strace presented it as otherwise:

```
1940  bind(3, {sa_family=AF_NETLINK, nl_pid=0, nl_groups=00000000}, 12) = 0
```

It seems that my virtual OS supports passing `sockaddr_nl` structs to a `bind` call (Read more [here](http://man7.org/linux/man-pages/man7/netlink.7.html)]). Simple changes to the `assert` statements are introduced to mitigate this.

Please let me know if any changes need to be made. After making these changes, my injector was able to continue execution (but stopped because of `syscallreplay` unsupported reasons, will create issues for more information), but I don't know if they will on another environment.