### PR TITLE
Added AST generation support for strace mutation

### DIFF
--- a/posix_omni_parser/Trace.py
+++ b/posix_omni_parser/Trace.py
@@ -19,9 +19,11 @@
 
 import os
 import sys
+import json
 
+import Syscall
 from parsers.StraceParser import StraceParser
-
+from parsers.ASTParser import ASTParser
 
 class Trace:
     """
@@ -115,6 +117,68 @@ class Trace:
         # - gathered from.
 
 
+    def to_ast(self):
+        """
+        <Purpose>
+          CRASHSIMULATOR MODIFIED
+
+          Generate a JSON-ready AST of the trace in order for
+          better anomaly injection. For each system call, store the
+          PID, name, arguments and return value in a dict, and append to
+          a parse tree list.
+
+        <Returns>
+          None
+
+        """
+
+        parse_tree = []
+
+        for syscall in self.syscalls:
+            ast = {
+              'type': syscall.type,
+              'pid': syscall.pid,
+              'name': syscall.name,
+              'args': [
+                  arg.to_ast(num) for num, arg in enumerate(syscall.args)
+              ],
+              'return': syscall.ret[0]
+            }
+            parse_tree.append(ast)
+
+        # return the parse tree with all system calls
+        return parse_tree
+
+
+    def from_ast(self, trace_ast):
+      """
+      <Purpose>
+        CRASHSIMULATOR MODIFIED
+
+        From a (mutated) AST, reimport into the trace object, replacing
+        self.syscalls with the altered changes. From here, execution from
+        CrashSimulator context can continue.
+
+      <Returns>
+        None
+
+      """
+
+      # store the original syscalls elsewhere and delete it.
+      self.orig_syscalls = self.syscalls
+      del self.syscalls
+
+      # reinitialize the parser as an ASTParser
+      self.parser = ASTParser(trace_ast, None, self.pickle_file)
+
+      # load the AST object back into a posix-omni-parser object
+      self.syscalls = self.parser.parse_trace()
+
+      # ensure that the original syscalls and the newly parsed system calls
+      # are not the same
+      assert not self.orig_syscalls == self.syscalls
+
+
     def __repr__(self):
         representation = "<Trace\nplatform=" + self.platform \
                        + "\ntrace_path=" + self.trace_path \
@@ -123,4 +187,3 @@ class Trace:
                        + "\ntraced_syscalls=" + str(len(self.syscalls)) + ">"
 
         return representation
-

--- a/posix_omni_parser/Trace.py
+++ b/posix_omni_parser/Trace.py
@@ -174,10 +174,6 @@ class Trace:
       # load the AST object back into a posix-omni-parser object
       self.syscalls = self.parser.parse_trace()
 
-      # ensure that the original syscalls and the newly parsed system calls
-      # are not the same
-      assert not self.orig_syscalls == self.syscalls
-
 
     def __repr__(self):
         representation = "<Trace\nplatform=" + self.platform \

--- a/posix_omni_parser/parsers/ASTParser.py
+++ b/posix_omni_parser/parsers/ASTParser.py
@@ -1,0 +1,85 @@
+"""
+<Started>
+  September 2018
+
+<Author>
+  Alan Cao
+
+<Purpose>
+  This module holds a set of methods to parse a trace serialized as an AST.
+
+  The path to a file generated must be passed to the constructor method 
+  when initializing a StraceParser object. Then the parse_trace method 
+  of the parser can be called, which will return a list of Syscall objects, 
+  each containing all the information about a single system call parsed 
+  from the AST
+
+"""
+
+from .. import Syscall
+from .Parser import Parser
+
+import json
+
+DEBUG = False
+
+
+class ASTParser(Parser):
+    """
+    <Purpose>
+    
+    <Attributes>
+      self.trace_path:
+        The path to the file containing JSON with system calls
+
+      self.syscall_definitions:
+        A list of definitions describing each system calls
+
+    """
+
+    def __init__(self, trace_ast, *args, **kwargs):
+        """
+        <Purpose>
+          Creates a ASTParser object  containing all the information needed to
+          extract data from a trace file generated from this library as an AST.
+        
+        <Arguments>
+          trace_path:
+            The path to the trace file containing the traced system calls. This file
+            should contain the output of an originally generated AST object.
+          pickle_file:
+            The path to the pickle file containing the parsed system call
+            representations.
+
+				<Side Effects>
+          None
+        
+        <Returns>
+          None
+        """
+        self.trace_ast = trace_ast
+        super(ASTParser, self).__init__(*args, **kwargs)
+
+    def _detect_trace_options(self):
+        pass
+
+    def _get_home_environment(self):
+        pass
+
+    def parse_trace(self):
+
+        # finished system calls
+        syscalls = []
+
+        # prioritize trace_path if exists
+        if self.trace_path != None:
+            with open(self.trace_path) as handler:
+                ast_obj = json.load(handler)
+        else:
+            ast_obj = self.trace_ast
+
+        for syscall_ast in ast_obj:
+            syscalls.append(Syscall.Syscall(self.syscall_definitions, None,
+                                        syscall_ast))
+
+        return syscalls

--- a/posix_omni_parser/parsers/ASTParser.py
+++ b/posix_omni_parser/parsers/ASTParser.py
@@ -80,6 +80,6 @@ class ASTParser(Parser):
 
         for syscall_ast in ast_obj:
             syscalls.append(Syscall.Syscall(self.syscall_definitions, None,
-                                        syscall_ast))
+                                        syscall_ast, parse_mode=1))
 
         return syscalls

--- a/posix_omni_parser/parsers/Parser.py
+++ b/posix_omni_parser/parsers/Parser.py
@@ -14,7 +14,7 @@
 import pickle
 
 
-class Parser():
+class Parser(object):
 
     def __init__(self, trace_path, pickle_file):
         """

--- a/posix_omni_parser/parsing_classes.py
+++ b/posix_omni_parser/parsing_classes.py
@@ -19,11 +19,46 @@ import socket
 DEBUG = False
 
 class ParsingClass:
+
     def __repr__(self):
         return "<" + self.__class__.__name__ + " " + str(self.value) + ">"
 
     def __str__(self):
         return str(self.value)
+
+    def to_ast(self, arg_num):
+        """
+        <Purpose>
+          CRASHSIMULATOR MODIFIED
+
+          Method that turns argument into serialized object for better consumption
+          as an AST during mutation.
+
+        <Returns>
+          A Python dictionary with the following attributes when represented in JSON:
+            args: [
+              {
+                "arg_num": 1,
+                "class": ArgClass,
+                "value": 0x10
+              },
+              ...
+            ]
+
+        """
+        # get the class of the parsed argument
+        arg_class = self.__class__.__name__
+
+        # check class type to ensure exceptions don't occur when serializing
+        if arg_class == "MissingValue":
+            return dict({"arg_num": arg_num,
+                         "class": arg_class,
+                         "value": None})
+
+        # otherwise, return normally
+        return dict({"arg_num": arg_num,
+                     "class": self.__class__.__name__,
+                     "value": str(self.value)})
 
 
 # This class is used to wrap all arguments for which a specific type is not yet


### PR DESCRIPTION
This pull request adds the generation of a Pythonic abstract syntax tree from raw `strace`, making it ideal for CrashSimulator mutation.

Most of the work has been done through extending the `Trace` interface, but adding support for the `to_ast()` and `from_ast()` instance methods, as seen in this example:

```
from posix_omni_parser import Trace

trace = Trace.Trace("/path/to/trace", "/path/to/syscall_definitions.pickle")

# generate AST
mutable_ast = trace.to_ast()

######
# ... perform mutation to trace
######

# convert back to object
trace.from_ast(mutable_ast)
```

This is a snippet of the trace that could be produced as an AST:

```
{
    'name': 'read'
    'pid': '3172', 
    'args': [
        {'arg_num': 0, 'class': 'FileDescriptor', 'value': '3'}, 
        {'arg_num': 1, 'class': 'UnimplementedType', 'value': '""'}, 
        {'arg_num': 2, 'class': 'Hex', 'value': '1024'}
    ], 
   'type': 2,
   'return': 0, 
},
```

## Features

* Extension of `Trace` object for AST generation and import/export
* Addition of `ASTParser` for actually generating the parse tree with support for Pythonic querying and mutation
* Extension of `Syscall.py` and `parsing_classes.py` for AST representation support.
